### PR TITLE
Update dummies.c for incorrect checksum function

### DIFF
--- a/stack_and_service/net/core/dummies.c
+++ b/stack_and_service/net/core/dummies.c
@@ -445,7 +445,7 @@ __wsum csum_partial_generic(const void *src, int len, __wsum currsum,int *src_er
      }
      REDUCE;
 finished:
-     return (~sum & 0xffff);
+     return (sum & 0xffff);
 }
 
 int __must_check kstrtoul(const char *s, unsigned int base, unsigned long *res)


### PR DESCRIPTION
For csum_partial the result is intermediate which should not be inverted. Otherwise, some packets such as RST relying on this for checksum calculation will be incorrect.